### PR TITLE
updated envelope handling

### DIFF
--- a/lib/src/envelope.rs
+++ b/lib/src/envelope.rs
@@ -1,6 +1,7 @@
 use crate::interpolation::Interpolation;
 use crate::buffer::Buffer;
 
+#[derive(Clone, Copy)]
 pub struct BreakPoints<const N: usize, const M: usize> {
   pub values: [f32; N],
   pub durations: [f32; M],


### PR DESCRIPTION
Allows for easier handling of BreakPoints-structs embedded in the EnvType enum, and being able to update envelopes with new BreakPoints values using methods that take both kinds of the EnvType, the breakpoints type and the vector type, as in the PolyTable-struct